### PR TITLE
[調査] Style/SuperWithArgsParentheses and Style/MethodCallWithArgsParentheses cause infinite loop #12437

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -203,3 +203,7 @@ Gemspec/DependencyVersion:
 
 Style/RequireOrder:
   Enabled: true
+
+Style/MethodCallWithArgsParentheses:
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -207,3 +207,11 @@ Style/RequireOrder:
 Style/MethodCallWithArgsParentheses:
   EnforcedStyle: omit_parentheses
   AllowParenthesesInMultilineCall: true
+  Enabled: true
+
+# Style/SuperWithArgsParentheses:
+#   Enabled:
+#     - 'foo.rb'
+
+Style/Documentation:
+  Enabled: false

--- a/foo.rb
+++ b/foo.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Foo
+  def foo(arg)
+    pp arg
+  end
+end
+
+class Bar < Foo
+  def foo(arg)
+   super(arg)
+  end
+end

--- a/hoge.rb
+++ b/hoge.rb
@@ -9,5 +9,6 @@ end
 class Bar < Foo
   def foo(arg)
     super(arg)
+    pp args
   end
 end


### PR DESCRIPTION
# これはなに

https://github.com/rubocop/rubocop の issue#12437 を調査して結果を記述するissueです

# 実行コマンド

```
bundle exec exe/rubocop --only Style/SuperWithArgsParentheses,Style/MethodCallWithArgsParentheses -A foo.rb
```

# 環境

```
bundle exec exe/rubocop -V
1.59.0 (using Parser 3.2.2.4, rubocop-ast 1.30.0, running on ruby 3.2.2) [x86_64-darwin21]
  - rubocop-performance 1.20.1
  - rubocop-rake 0.6.0
  - rubocop-rspec 2.25.0
```

issueではrubocop v1.58.0となっているがv1.59.0でもエラーになる