### PR TITLE
[調査] Infinite loop with Layout/RedundantLineBreak and Style/SingleLineDoEndBlock #12597

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,8 +48,8 @@ Layout/EndOfLine:
 Layout/ClassStructure:
   Enabled: true
 
-Layout/RedundantLineBreak:
-  Enabled: true
+# Layout/RedundantLineBreak:
+#   Enabled: true
 
 Layout/TrailingWhitespace:
   AllowInHeredoc: false
@@ -202,4 +202,11 @@ Gemspec/DependencyVersion:
   Enabled: true
 
 Style/RequireOrder:
+  Enabled: true
+
+Layout/RedundantLineBreak:
+  Enabled: true
+  InspectBlocks: true
+
+Style/SingleLineDoEndBlock:
   Enabled: true

--- a/foo.rb
+++ b/foo.rb
@@ -1,0 +1,7 @@
+def foo
+  a.each do |x|
+    x.each do |y|
+      bar y
+    end
+  end
+end


### PR DESCRIPTION
# これはなに

https://github.com/rubocop/rubocop の issues/12597 を調査して結果を記述するissueです

# 実行コマンド

```
bundle exec exe/rubocop --only Layout/RedundantLineBreak,Style/SingleLineDoEndBlock -A foo.rb
```

# 環境

```
bundle exec exe/rubocop -V
1.59.0 (using Parser 3.3.0.2, rubocop-ast 1.30.0, running on ruby 3.2.2) [x86_64-darwin22]
  - rubocop-performance 1.20.2
  - rubocop-rake 0.6.0
  - rubocop-rspec 2.26.1
```